### PR TITLE
Add `delete` functionality

### DIFF
--- a/include/comps_offsets.h
+++ b/include/comps_offsets.h
@@ -3,4 +3,4 @@
 #define COMP_OFFSET_PCC 16
 #define COMP_OFFSET_STK_ADDR 32
 
-#define MAX_COMP_COUNT 2
+#define MAX_COMP_COUNT 3

--- a/src/manager.S
+++ b/src/manager.S
@@ -129,3 +129,70 @@ add_compartment:
     b.gt      abort
 
     ret
+
+/**
+ * Function to delete an existing compartment data
+ *
+ * @param x0 Function of compartment to be deleted
+ */
+/* TODO there is a potential issue of a compartment saving a capability it was
+ * provided to it for use (i.e., PCC, DDC), such as by storing it in the memory
+ * of another compartment. If the original compartment gets deleted, and a new
+ * compartment is allocated in the same memory region, we have leaked a
+ * capability referencing the new compartment.
+ * TODO currently, this function shifts subsequent data following a delete
+ * compartment meta-data in its place. It would be possible for a malicious
+ * compartment to inject valid malicious data in the space subsequent to this
+ * area of code, and somehow that data can be misused by the switcher. One
+ * option is to zero out respective memory, or to allocate a larger space than
+ * actually needed, to prevent this.*/
+.type del_compartment, "function"
+del_compartment:
+
+    // Find capabilities (DDC/PCC) of given compartment
+    ldr       x1, comps_addr
+    ldr       w3, comps_cnt
+
+pcc_check_start:
+    subs      w3, w3, #1
+    b.mi      pcc_not_found
+    ldr       c4, [x1, #COMP_OFFSET_PCC] // get current stored PCC to check
+    gcvalue   x4, c4
+    cmp       x4, x0 // check value of current PCC against given function
+    b.eq      pcc_found
+    add       x1, x1, #COMP_SIZE // go check next PCC
+    b         pcc_check_start
+
+pcc_not_found:
+    b         abort
+
+pcc_found:
+    // We found the address to the start of the compartment info area, at
+    // address `$x1`
+    stp       x1, lr, [sp, #-16]! // store `x1` and `lr`
+    ldr       c2, [x1, #COMP_OFFSET_DDC]
+
+    // Unmap memory region allocated
+    gcvalue   x0, c2
+    gclen     x1, c2
+    bl        munmap
+    cmp       x0, #-1
+    b.eq      abort // munmap failed
+    ldp       x0, lr, [sp], #16
+
+    // Shift subsequent capabilities forward (if we delete the last
+    // compartment, we put gibberish instead)
+    ldr       w5, comps_cnt
+    mov       x6, #COMP_SIZE
+    ldr       x7, comps_addr
+    madd      x5, x5, x6, x7 // Get last allocated compartment address
+shift_next_comp:
+    ldp       c2, c3, [x0, #COMP_SIZE]        // load next compartment data
+    stp       c2, c3, [x0]                    // .. and store
+    ldr       x2, [x0, #(COMP_SIZE + COMP_OFFSET_STK_ADDR)]
+    str       x2, [x0, #COMP_OFFSET_STK_ADDR]
+    add       x0, x0, #COMP_SIZE
+    cmp       x0, x5
+    b.lt      shift_next_comp
+
+    ret

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,3 +8,4 @@ endfunction()
 
 new_proj_test(simple_init)
 new_proj_test(simple_add)
+new_proj_test(simple_delete)

--- a/tests/simple_delete.c
+++ b/tests/simple_delete.c
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+#include "cheriintrin.h"
+
+#include "comps_offsets.h"
+
+static_assert(COMP_SIZE == sizeof(void* __capability) * 3, "Invalid `COMP_SIZE` provided");
+static_assert(COMP_OFFSET_DDC == 0, "Invalid `COMP_OFFSET_DDC` provided.");
+static_assert(COMP_OFFSET_PCC == sizeof(void* __capability) * 1, "Invalid `COMP_OFFSET_PCC` provided.");
+static_assert(COMP_OFFSET_STK_ADDR == sizeof(void* __capability) * 2, "Invalid `COMP_OFFSET_STK_LEN` provided.");
+
+/*******************************************************************************
+ * Extern functions
+ ******************************************************************************/
+
+extern void* __capability * comps_addr;
+extern size_t comps_cnt;
+
+extern void* init_compartments();
+extern void* add_compartment(size_t, void*);
+extern void* del_compartment(void*);
+
+/*******************************************************************************
+ * Main
+ ******************************************************************************/
+
+int comp_f_fn();
+int comp_g_fn();
+int comp_h_fn();
+
+/**
+ * Checks whether a (DDC, PCC) pair at a given offset into the `comps_addr`
+ * pseudo-array are valid, and point to the given function.
+ *
+ * @param id Offset into `comps_addr` array, where we expect a DDC cap,
+ *           followed by a PCC cap
+ * @param func Pointer to function expected in the PCC
+ */
+void
+check_valid_compartment_caps(size_t id, void* func)
+{
+    const size_t comps_fields_count = 3;
+    void* __capability comp_ddc = comps_addr[id * comps_fields_count];
+    assert(cheri_is_valid(comp_ddc));
+
+    void* __capability comp_pcc = comps_addr[id * comps_fields_count + 1];
+    assert(cheri_is_valid(comp_pcc));
+    assert(cheri_address_get(comp_pcc) == (unsigned long) func);
+}
+
+int
+main()
+{
+    init_compartments();
+
+    size_t comp_size = 2000;
+    assert(add_compartment(comp_size, comp_f_fn) != MAP_FAILED);
+    assert(add_compartment(comp_size, comp_g_fn) != MAP_FAILED);
+    assert(add_compartment(comp_size, comp_h_fn) != MAP_FAILED);
+
+    assert(comps_cnt == 3);
+    check_valid_compartment_caps(0, comp_f_fn);
+    check_valid_compartment_caps(1, comp_g_fn);
+    check_valid_compartment_caps(2, comp_h_fn);
+
+    del_compartment(comp_g_fn);
+
+    check_valid_compartment_caps(0, comp_f_fn);
+    check_valid_compartment_caps(1, comp_h_fn);
+    assert(!cheri_is_valid(comps_addr[2 * 3 + 0]));
+    assert(!cheri_is_valid(comps_addr[2 * 3 + 1]));
+
+    int (*fn)() = (__cheri_fromcap int(*)()) comps_addr[1 * 3 + 1];
+    assert(fn() == 420);
+
+    return 0;
+}
+
+/*******************************************************************************
+ * Compartments
+ ******************************************************************************/
+
+int
+comp_f_fn()
+{
+    return 42;
+}
+
+int
+comp_g_fn()
+{
+    return 24;
+}
+
+int
+comp_h_fn()
+{
+    return 420;
+}


### PR DESCRIPTION
We want to allow deletion of a previously added compartment. This
involves deallocating the respective memory, and removing references to
the saved capabilities from the switcher's table.